### PR TITLE
Feature/use lints over pedantic

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.11.0.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude: [example/**]

--- a/lib/src/services/arb_generator.dart
+++ b/lib/src/services/arb_generator.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: implementation_imports
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   equatable:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: excel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-null-safety"
+    version: "2.0.0-null-safety-3"
   file:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: flappy_translator
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-nullsafety.1"
+    version: "2.0.0-nullsafety.2"
   glob:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,6 +162,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  lints:
+    dependency: "direct dev"
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -212,7 +219,7 @@ packages:
     source: hosted
     version: "1.8.0"
   pedantic:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   yaml: ^3.1.0
-  flappy_translator: 2.0.0-nullsafety.1
+  flappy_translator: 2.0.0-nullsafety.2
 
 dev_dependencies:
   test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
 
 dev_dependencies:
   test: ^1.16.8
-  pedantic: ^1.11.0
+  lints: ^1.0.1


### PR DESCRIPTION
- Use lints over pedantic for analyzer.
- Update to use latest flappy_translator