### PR TITLE
Update section 'Define Settings' with actual 'output_directory' key

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Next define arb_generator package settings in `pubspec.yaml`. Note that `input_f
 ```yaml
 arb_generator:
   input_filepath: "assets_dev/test.csv"
-  output_filepath: "lib/l10n"
+  output_directory: "lib/l10n"
   filename_prepend: "intl_"
   csv_settings:
     delimiter: ";"
@@ -68,7 +68,7 @@ arb_generator:
 | Setting                         | Description                                                                   |
 | ------------------------------- | ------------------------------------------------------------------------------|
 | input_filepath                  | Required. A path to the input CSV file.                                       |
-| output_dir                      | A directory to generate the output ARB file(s). Defaults to `lib/l10`         |
+| output_directory                | A directory to generate the output ARB file(s). Defaults to `lib/l10`         |
 | filename_prepend                | Text to prepend to filename of generated files. Fefaults to empty string.     |
 | csv_settings: delimiter         | A delimiter to separate columns in the input CSV file. Defaults to `,`.       |
 | csv_settings: description_index | The description column index. Defaults to `null`.                             |

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -33,7 +33,7 @@ flutter_intl:
 
 arb_generator:
   input_filepath: "assets_dev/test.csv"
-  output_filepath: "lib/l10n"
+  output_directory: "lib/l10n"
   filename_prepend: "intl_"
   csv_settings:
     delimiter: ";"


### PR DESCRIPTION
In the section 'Define Settings', both the example configuration and table with setting descriptions showed an inaccurate value for the key 'output_directory'.
This PR updates the README.md file to properly reflect the actual value of the key as specified in code.